### PR TITLE
update module s.t. we can install with `go install ...`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module tcli
+module github.com/c4pt0r/tcli
 
 go 1.16
 


### PR DESCRIPTION
Otherwise

```bash
$ go install github.com/c4pt0r/tcli@latest
go: downloading github.com/c4pt0r/tcli v0.0.0-20211209143356-b0706808a1f0
go install: github.com/c4pt0r/tcli@latest: github.com/c4pt0r/tcli@v0.0.0-20211209143356-b0706808a1f0: parsing go.mod:
	module declares its path as: tcli
	        but was required as: github.com/c4pt0r/tcli
```