### PR TITLE
Rawkv

### DIFF
--- a/client/rawkv_client.go
+++ b/client/rawkv_client.go
@@ -47,11 +47,11 @@ func (c *rawkvClient) GetClusterID() string {
 }
 
 func (c *rawkvClient) GetStores() ([]StoreInfo, error) {
-	return nil, errors.New("rawkvClient.GetStores() is not implemented")
+	return nil, errors.New("rawkvClient does not support GetStores()")
 }
 
 func (c *rawkvClient) GetPDClient() pd.Client {
-	log.Fatal("rawkvClient.GetPDClient() is not implemented")
+	log.Fatal("rawkvClient does not support GetPDClient()")
 	return nil
 }
 


### PR DESCRIPTION
Implemented most functions in rawKV client. Currently, a few functions such as getPDClient and getStores cannot be implemented because the rawKV client does not export its pd client attribute.

rawkv mode can be used by setting flag `-mode=raw` when running tcli