### PR TITLE
redirect logging output to stderr

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/c4pt0r/tcli"
 	"github.com/c4pt0r/tcli/client"
@@ -65,7 +66,8 @@ func initLog() {
 }
 
 func showWelcomeMessage() {
-	fmt.Printf(
+	fmt.Fprintf(
+		os.Stderr,
 		"Welcome, TiKV Cluster ID: %s, TiKV Mode: %s\n",
 		client.GetTiKVClient().GetClusterID(),
 		client.GetTiKVClient().GetClientMode(),
@@ -96,11 +98,11 @@ func showWelcomeMessage() {
 func main() {
 	flag.Parse()
 	initLog()
-	fmt.Printf("Try connecting to PD: %s...", *pdAddr)
+	fmt.Fprintf(os.Stderr, "Try connecting to PD: %s...", *pdAddr)
 	if err := client.InitTiKVClient([]string{*pdAddr}, *clientmode); err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("done\n")
+	fmt.Fprintf(os.Stderr, "done\n")
 	utils.InitBuiltinVaribles()
 	showWelcomeMessage()
 
@@ -113,6 +115,7 @@ func main() {
 		pdLeaderAddr := client.GetTiKVClient().GetPDClient().GetLeaderAddr()
 		shell.SetPrompt(fmt.Sprintf("%s(%s)> ", client.GetTiKVClient().GetClientMode(), pdLeaderAddr))
 	}
+	shell.EOF(func(c *ishell.Context) { shell.Close() })
 
 	// register shell commands
 	for _, cmd := range RegisteredCmds {
@@ -123,9 +126,9 @@ func main() {
 			Aliases: cmd.Alias(),
 			Func: func(c *ishell.Context) {
 				ctx := context.WithValue(context.TODO(), "ishell", c)
-				fmt.Println(color.WhiteString("Input:"), c.RawArgs)
+				fmt.Fprintln(os.Stderr, color.WhiteString("Input:"), c.RawArgs)
 				for _, arg := range c.Args {
-					fmt.Println(color.WhiteString("Arg:"), arg)
+					fmt.Fprintln(os.Stderr, color.WhiteString("Arg:"), arg)
 				}
 				handler(ctx)
 			},

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync/atomic"
 
@@ -52,9 +53,9 @@ func (kvs KVS) Print() {
 			}
 			utils.PrintTable(data)
 			if len(kvs) > 1 {
-				fmt.Printf("%d Records Found\n", len(kvs))
+				fmt.Fprintf(os.Stderr, "%d Records Found\n", len(kvs))
 			} else {
-				fmt.Printf("%d Record Found\n", len(kvs))
+				fmt.Fprintf(os.Stderr, "%d Record Found\n", len(kvs))
 			}
 		}
 	case JsonFormat:

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -35,9 +35,9 @@ func OutputWithElapse(f func() error) error {
 	tt := time.Now()
 	err := f()
 	if err != nil {
-		fmt.Printf("Error: %s, Elapse: %d ms\n", err, time.Since(tt)/time.Millisecond)
+		fmt.Fprintf(os.Stderr, "Error: %s, Elapse: %d ms\n", err, time.Since(tt)/time.Millisecond)
 	} else {
-		fmt.Printf("Success, Elapse: %d ms\n", time.Since(tt)/time.Millisecond)
+		fmt.Fprintf(os.Stderr, "Success, Elapse: %d ms\n", time.Since(tt)/time.Millisecond)
 	}
 	return err
 }


### PR DESCRIPTION
Redirect logging output to stderr, as proposed in #11. Also configured ishell to exit immediately on EOF without printing an error to stdout (ishell runs into EOF when piping in commands via echo or printf).

After these changes, only returned key-value pairs are output to Stdout.