### PR TITLE
Refactor and fix JSON output formatting

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -22,37 +22,17 @@ type KV struct {
 	V Value
 }
 
-type KVString struct {
-	K string
-	V string
-}
-
 type KVS []KV
 
-//type KVSFormatter int
-
-const (
-	TableFormat = iota + 1000
-	JsonFormat
-)
-
-func Stringify(kvs KVS) []KVString {
-	KVStrings := make([]KVString, len(kvs))
-	for i := 0; i < len(kvs); i++ {
-		KVStrings[i] = KVString{string(kvs[i].K), string(kvs[i].V)}
-	}
-	return KVStrings
-}
-
 func (kvs KVS) Print() {
-	formatter := TableFormat
+
+	formatter := "table"
 	if r, ok := utils.SysVarGet(utils.SysVarPrintFormatKey); ok {
-		if string(r) == "json" {
-			formatter = JsonFormat
-		}
+		formatter = string(r)
 	}
+
 	switch formatter {
-	case TableFormat:
+	case "table":
 		{
 			if len(kvs) == 0 {
 				return
@@ -71,10 +51,15 @@ func (kvs KVS) Print() {
 				fmt.Fprintf(os.Stderr, "%d Record Found\n", len(kvs))
 			}
 		}
-	case JsonFormat:
+	case "json":
 		{
-			fmt.Print(Stringify(kvs))
-			out, _ := json.MarshalIndent(Stringify(kvs), "", " ")
+			//Convert key value pairs to string or else JSON Marshaling breaks
+			kvmaps := make([]map[string]string, len(kvs))
+			for i := 0; i < len(kvs); i++ {
+				kvmaps[i] = make(map[string]string)
+				kvmaps[i]["K"], kvmaps[i]["V"] = string(kvs[i].K), string(kvs[i].V)
+			}
+			out, _ := json.MarshalIndent(kvmaps, "", " ")
 			fmt.Println(string(out))
 		}
 	default:

--- a/client/client.go
+++ b/client/client.go
@@ -22,14 +22,27 @@ type KV struct {
 	V Value
 }
 
+type KVString struct {
+	K string
+	V string
+}
+
 type KVS []KV
 
-type KVSFormatter int
+//type KVSFormatter int
 
 const (
 	TableFormat = iota + 1000
 	JsonFormat
 )
+
+func Stringify(kvs KVS) []KVString {
+	KVStrings := make([]KVString, len(kvs))
+	for i := 0; i < len(kvs); i++ {
+		KVStrings[i] = KVString{string(kvs[i].K), string(kvs[i].V)}
+	}
+	return KVStrings
+}
 
 func (kvs KVS) Print() {
 	formatter := TableFormat
@@ -60,7 +73,8 @@ func (kvs KVS) Print() {
 		}
 	case JsonFormat:
 		{
-			out, _ := json.MarshalIndent(kvs, "", " ")
+			fmt.Print(Stringify(kvs))
+			out, _ := json.MarshalIndent(Stringify(kvs), "", " ")
 			fmt.Println(string(out))
 		}
 	default:


### PR DESCRIPTION
Part of #11. Refactored output formatting in client/client.go. Also changed JSON output formatting to convert to strings before marshaling; previous implementation would directly marshal the array of KV structs, causing unexpected behavior when handling the byte array keys and values.

Currently, there is no way to change output formatting inside tcli without rebuilding it. In order to test these changes, you can go to utils/variables.go and change the value of `SysVarPrintFormatKey` to `json`, and then build the application again.

https://github.com/c4pt0r/tcli/blob/d6ed5b2077a0abe34f2f8a50b4abb6c22a2997d9/utils/variables.go#L23

![image](https://user-images.githubusercontent.com/7188032/184262200-65ff175c-6116-4402-a69f-125e9d8f03a9.png)

