### PR TITLE
Enabled edit sysenv command

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -50,7 +50,7 @@ var RegisteredCmds = []tcli.Cmd{
 	kvcmds.VarCmd{},
 	kvcmds.PrintVarsCmd{},
 	kvcmds.PrintSysVarsCmd{},
-
+	kvcmds.SysVarCmd{},
 	opcmds.ListStoresCmd{},
 	//opcmds.ConnectCmd{},
 	//opcmds.ConfigEditorCmd{},

--- a/client/client.go
+++ b/client/client.go
@@ -54,10 +54,11 @@ func (kvs KVS) Print() {
 	case "json":
 		{
 			//Convert key value pairs to string or else JSON Marshaling breaks
-			kvmaps := make([]map[string]string, len(kvs))
+			kvmaps := make([]map[string]interface{}, len(kvs))
 			for i := 0; i < len(kvs); i++ {
-				kvmaps[i] = make(map[string]string)
-				kvmaps[i]["K"], kvmaps[i]["V"] = string(kvs[i].K), string(kvs[i].V)
+				kvmaps[i] = make(map[string]interface{})
+				//kvmaps[i]["K"], kvmaps[i]["V"] = string(kvs[i].K), string(kvs[i].V)
+				kvmaps[i][string(kvs[i].K)] = string(kvs[i].V)
 			}
 			out, _ := json.MarshalIndent(kvmaps, "", " ")
 			fmt.Println(string(out))


### PR DESCRIPTION
Enabled edit sysenv command to edit system environment variables. Current usage: `sysvar [name]="[value]"`

![image](https://user-images.githubusercontent.com/7188032/185719582-d0987739-796d-48e0-aad7-89e0f9c4fbf5.png)

With these changes, it is now possible to change output format inside tcli.