### PR TITLE
Support to release via goreleaser

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.0
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.16.x
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2.9.1
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PUBLISH_SECRETS }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 bin/
+.idea/
+release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,30 @@
+# Official documentation at http://goreleaser.com
+project_name: tcli
+builds:
+  - env:
+      - CGO_ENABLED=0
+    binary: tcli
+    main: ./cli/main.go
+    goos:
+      - windows
+      - linux
+      - darwin
+    ignore:
+      - goarch: arm
+      - goarch: arm64
+      - goarch: 386
+    ldflags:
+      - -w
+      - -s
+dist: release
+archives:
+  - name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - README.md
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next-{{.ShortCommit}}"


### PR DESCRIPTION
See the test process:

```shell
@LinuxSuRen ➜ /workspaces/tcli (release) $ goreleaser build --rm-dist --snapshot
  • starting build...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • couldn't find any tags before "v0.0.1"
    • building...                                    commit=bb1aa985113d164fb23014cdf9caa6f96b2fa1b9 latest tag=v0.0.1
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.0.1-next-bb1aa98
  • checking distribution directory
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=release/config.yaml
  • building binaries
    • building                                       binary=release/tcli_darwin_amd64_v1/tcli
    • building                                       binary=release/tcli_windows_amd64_v1/tcli.exe
    • building                                       binary=release/tcli_linux_amd64_v1/tcli
    • took: 1m23s
  • storing release metadata
    • writing                                        file=release/artifacts.json
    • writing                                        file=release/metadata.json
  • build succeeded after 1m23s
@LinuxSuRen ➜ /workspaces/tcli (release) $ ./release/tcli_linux_amd64_v1/tcli -h
Usage of ./release/tcli_linux_amd64_v1/tcli:
  -log-file string
        TiKV client log file (default "/dev/null")
  -log-level string
        TiKV client log level (default "info")
  -mode string
        TiKV API mode, accepted values: [raw | txn] (default "txn")
  -output-format string
        output format, accepted values: [table | json] (default "table")
  -pd string
        PD addr (default "localhost:2379")
```

## Attention
Before merging this PR, please don't forget to add the following secret to this repository:

* `GH_PUBLISH_SECRETS` is the GitHub personal token which has the permission to upload files into the release

fix #22