### PR TITLE
Fix backup command 

### DIFF
--- a/kvcmds/cmd_backup.go
+++ b/kvcmds/cmd_backup.go
@@ -81,8 +81,8 @@ func (c BackupCmd) Handler() func(ctx context.Context) {
 			csvWriter.Write([]string{"Key", "Value"})
 
 			opt := properties.NewProperties()
-			if len(ic.Args) > 1 {
-				err := utils.SetOptByString(ic.Args[1:], opt)
+			if len(ic.Args) > 2 {
+				err := utils.SetOptByString(ic.Args[2:], opt)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Fixes #24 simply by changing the index on which the scans for flags would start. This was previously index 1 which contradicts the current help page and implemented logic, it was changed to 2.