### PR TITLE
Add JSON value access support in query module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ bin/
 .idea/
 release
 *.pprof
+query/testdata

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.16
 	github.com/abiosoft/ishell v2.0.0+incompatible
+	github.com/beorn7/perks v1.0.1
 	github.com/c4pt0r/log v0.0.0-20211004143616-aa6380016a47
 	github.com/fatih/color v1.12.0
 	github.com/magiconair/properties v1.8.0
@@ -20,7 +21,6 @@ require (
 
 require (
 	github.com/abiosoft/readline v0.0.0-20180607040430-155bce2042db // indirect
-	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect

--- a/kvcmds/cmd_explain.go
+++ b/kvcmds/cmd_explain.go
@@ -44,7 +44,7 @@ func (c ExplainCmd) Handler() func(ctx context.Context) {
 			opt := query.NewOptimizer(sql)
 			plan, err := opt.BuildPlan(qtxn)
 			if err != nil {
-				return err
+				return bindQueryToError(sql, err)
 			}
 			ret := [][]string{
 				{"Plan"},

--- a/kvcmds/cmd_query.go
+++ b/kvcmds/cmd_query.go
@@ -59,6 +59,8 @@ func convertColumnToString(c query.Column) string {
 			return "true"
 		}
 		return "false"
+	case map[string]any, query.JSON, []any:
+		return fmt.Sprintf("%v", v)
 	default:
 		if v == nil {
 			return "nil"

--- a/kvcmds/cmd_query.go
+++ b/kvcmds/cmd_query.go
@@ -59,7 +59,7 @@ func convertColumnToString(c query.Column) string {
 			return "true"
 		}
 		return "false"
-	case map[string]any, query.JSON, []any:
+	case map[string]any, query.JSON, []any, []string, []int64, []float64:
 		return fmt.Sprintf("%v", v)
 	default:
 		if v == nil {

--- a/kvcmds/cmd_query.go
+++ b/kvcmds/cmd_query.go
@@ -82,12 +82,12 @@ func (c QueryCmd) Handler() func(ctx context.Context) {
 			opt := query.NewOptimizer(sql)
 			plan, err := opt.BuildPlan(qtxn)
 			if err != nil {
-				return err
+				return bindQueryToError(sql, err)
 			}
 			// ret, err := c.getRows(plan)
 			ret, err := c.getRowsBatch(plan)
 			if err != nil {
-				return err
+				return bindQueryToError(sql, err)
 			}
 			if len(ret) > 1 {
 				utils.PrintTable(ret)
@@ -97,6 +97,16 @@ func (c QueryCmd) Handler() func(ctx context.Context) {
 			}
 			return nil
 		})
+	}
+}
+
+func bindQueryToError(sql string, err error) error {
+	switch val := err.(type) {
+	case query.QueryBinder:
+		val.BindQuery(sql)
+		return err
+	default:
+		return err
 	}
 }
 

--- a/query/README.md
+++ b/query/README.md
@@ -52,7 +52,7 @@ CompareOperator ::= "=" | "!=" | "^=" | "~=" | ">" | ">=" | "<" | "<="
 KeyValueField ::= "KEY" | "VALUE"
 
 FunctionCall ::= FunctionName "(" FunctionArgs ")" |
-				 FunctionName "(" FunctionArgs ")" FieldAccessExpression*
+                 FunctionName "(" FunctionArgs ")" FieldAccessExpression*
 
 FunctionName ::= String
 
@@ -61,7 +61,7 @@ FunctionArgs ::= FunctionArg ("," FunctionArg)*
 FunctionArg ::= Expression
 
 FieldAccessExpression ::= "[" String "]" |
-					      "[" Number "]"
+                          "[" Number "]"
 ```
 
 Features:

--- a/query/README.md
+++ b/query/README.md
@@ -51,13 +51,16 @@ CompareOperator ::= "=" | "!=" | "^=" | "~=" | ">" | ">=" | "<" | "<="
 
 KeyValueField ::= "KEY" | "VALUE"
 
-FunctionCall ::= FunctionName "(" FunctionArgs ")"
+FunctionCall ::= FunctionName "(" FunctionArgs ")" |
+					FunctionName "(" FunctionArgs ")" FieldAccessExpression*
 
 FunctionName ::= String
 
 FunctionArgs ::= FunctionArg ("," FunctionArg)*
 
 FunctionArg ::= Expression
+
+FieldAccessExpression ::= "[" String "]"
 ```
 
 Features:
@@ -67,3 +70,20 @@ Features:
 3. Expression constant folding
 4. Support scalar function and aggregate function
 5. Support hash aggregate plan
+6. Support JSON and field access expression
+
+Examples:
+
+```
+# Simple query
+q select * where key ^= 'k'
+
+# Projection and complex condition
+q select key, int(value) + 1 where key in ('k1', 'k2', 'k3') & is_int(value)
+
+# Aggregation query
+q select count(1), sum(int(value)) as sum, substr(key, 0, 2) as kprefix where key between 'k' and 'l' group by kprefix order by sum desc
+
+# JSON access
+q select key, json(value)['x']['y'] where key ^= 'k' & int(json(value)['test']) >= 1
+```

--- a/query/README.md
+++ b/query/README.md
@@ -87,4 +87,5 @@ q select count(1), sum(int(value)) as sum, substr(key, 0, 2) as kprefix where ke
 
 # JSON access
 q select key, json(value)['x']['y'] where key ^= 'k' & int(json(value)['test']) >= 1
+q select key, json(value)['list'][1] where key ^= 'k'
 ```

--- a/query/README.md
+++ b/query/README.md
@@ -52,7 +52,7 @@ CompareOperator ::= "=" | "!=" | "^=" | "~=" | ">" | ">=" | "<" | "<="
 KeyValueField ::= "KEY" | "VALUE"
 
 FunctionCall ::= FunctionName "(" FunctionArgs ")" |
-					FunctionName "(" FunctionArgs ")" FieldAccessExpression*
+				 FunctionName "(" FunctionArgs ")" FieldAccessExpression*
 
 FunctionName ::= String
 
@@ -60,7 +60,8 @@ FunctionArgs ::= FunctionArg ("," FunctionArg)*
 
 FunctionArg ::= Expression
 
-FieldAccessExpression ::= "[" String "]"
+FieldAccessExpression ::= "[" String "]" |
+					      "[" Number "]"
 ```
 
 Features:

--- a/query/aggregate_plan.go
+++ b/query/aggregate_plan.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -75,10 +74,10 @@ func (a *AggregatePlan) listAggrFunctions(expr Expression) ([]*FunctionCallExpr,
 	for i, fname := range fnames {
 		functor, have := GetAggrFunctionByName(fname)
 		if !have {
-			return nil, nil, false, fmt.Errorf("Cannot find aggregate function: %s", fname)
+			return nil, nil, false, NewExecuteError(fcexprs[i].GetPos(), "Cannot find aggregate function: %s", fname)
 		}
 		if !functor.VarArgs && functor.NumArgs != len(fcexprs[i].Args) {
-			return nil, nil, false, fmt.Errorf("Function %s require %d arguments but got %d", functor.Name, functor.NumArgs, len(fcexprs[i].Args))
+			return nil, nil, false, NewExecuteError(fcexprs[i].GetPos(), "Function %s require %d arguments but got %d", functor.Name, functor.NumArgs, len(fcexprs[i].Args))
 		}
 		functors = append(functors, functor.Body())
 	}
@@ -270,7 +269,7 @@ func (a *AggregatePlan) updateRowAggrFunc(row []*AggrPlanField, kvp KVPair) erro
 		}
 		fcexprs := col.FuncExprs
 		if len(fcexprs) == 0 {
-			return errors.New("Cannot cast expression to function call expression")
+			return NewExecuteError(0, "Cannot cast expression to function call expression")
 		}
 		for i, fcexpr := range fcexprs {
 			err := col.Funcs[i].Update(kvp, fcexpr.Args)
@@ -534,6 +533,6 @@ func (a *AggregatePlan) convertToBytes(val any) ([]byte, error) {
 		if val == nil {
 			return nil, nil
 		}
-		return nil, errors.New("Expression result type not support")
+		return nil, NewExecuteError(0, "Expression result type not support")
 	}
 }

--- a/query/aggregate_plan.go
+++ b/query/aggregate_plan.go
@@ -79,7 +79,11 @@ func (a *AggregatePlan) listAggrFunctions(expr Expression) ([]*FunctionCallExpr,
 		if !functor.VarArgs && functor.NumArgs != len(fcexprs[i].Args) {
 			return nil, nil, false, NewExecuteError(fcexprs[i].GetPos(), "Function %s require %d arguments but got %d", functor.Name, functor.NumArgs, len(fcexprs[i].Args))
 		}
-		functors = append(functors, functor.Body())
+		fbody, err := functor.Body(fcexprs[i].Args)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		functors = append(functors, fbody)
 	}
 	return fcexprs, functors, true, nil
 }

--- a/query/checker.go
+++ b/query/checker.go
@@ -268,5 +268,5 @@ func (e *FieldAccessExpr) Check() error {
 			return nil
 		}
 	}
-	return NewSyntaxError(e.GetPos(), "Invalid field name")
+	return NewSyntaxError(e.FieldName.GetPos(), "Invalid field name")
 }

--- a/query/checker.go
+++ b/query/checker.go
@@ -88,6 +88,18 @@ func (e *BinaryOpExpr) checkWithMath() error {
 			return NewSyntaxError(e.Right.GetPos(), "%s operator with invalid right expression %s", op, e.Left)
 		}
 	}
+	if op == "/" {
+		switch rval := e.Right.(type) {
+		case *NumberExpr:
+			if rval.Int == 0 {
+				return NewSyntaxError(e.Right.GetPos(), "/ operator divide by zero")
+			}
+		case *FloatExpr:
+			if rval.Float == 0.0 {
+				return NewSyntaxError(e.Right.GetPos(), "/ operator divide by zero")
+			}
+		}
+	}
 	return nil
 }
 

--- a/query/checker.go
+++ b/query/checker.go
@@ -1,10 +1,5 @@
 package query
 
-import (
-	"errors"
-	"fmt"
-)
-
 func (e *BinaryOpExpr) Check() error {
 	if err := e.Left.Check(); err != nil {
 		return err
@@ -16,7 +11,7 @@ func (e *BinaryOpExpr) Check() error {
 	case And, Or:
 		return e.checkWithAndOr()
 	case Not:
-		return errors.New("Syntax Error: Invalid operator !")
+		return NewSyntaxError(e.GetPos(), "Invalid operator !")
 	case Add, Sub, Mul, Div:
 		return e.checkWithMath()
 	case In:
@@ -33,19 +28,19 @@ func (e *BinaryOpExpr) checkWithAndOr() error {
 	switch exp := e.Left.(type) {
 	case *BinaryOpExpr, *FunctionCallExpr, *NotExpr:
 		if e.Left.ReturnType() != TBOOL {
-			return fmt.Errorf("Syntax Error: %s operator has wrong type of left expression %s", op, exp)
+			return NewSyntaxError(e.Left.GetPos(), "%s operator has wrong type of left expression %s", op, exp)
 		}
 	default:
-		return fmt.Errorf("Syntax Error: %s operator with invalid left expression %s", op, exp)
+		return NewSyntaxError(e.Left.GetPos(), "%s operator with invalid left expression %s", op, exp)
 	}
 
 	switch exp := e.Right.(type) {
 	case *BinaryOpExpr, *FunctionCallExpr, *NotExpr:
 		if exp.ReturnType() != TBOOL {
-			return fmt.Errorf("Syntax Error: %s operator has wrong type of right expression %s", op, exp)
+			return NewSyntaxError(e.Right.GetPos(), "%s operator has wrong type of right expression %s", op, exp)
 		}
 	default:
-		return fmt.Errorf("Syntax Error: %s operator with invalid right expression %s", op, exp)
+		return NewSyntaxError(e.Right.GetPos(), "%s operator with invalid right expression %s", op, exp)
 	}
 	return nil
 }
@@ -60,13 +55,13 @@ func (e *BinaryOpExpr) checkWithMath() error {
 			if e.Left.ReturnType() == TSTR {
 				lstring = true
 			} else {
-				return fmt.Errorf("Syntax Error: %s operator has wrong type of left expression %s", op, exp)
+				return NewSyntaxError(e.Left.GetPos(), "%s operator has wrong type of left expression %s", op, exp)
 			}
 		}
 	case *StringExpr, *FieldExpr, *FieldAccessExpr:
 		lstring = true
 	default:
-		return fmt.Errorf("Syntax Error: %s operator with invalid left expression %s", op, exp)
+		return NewSyntaxError(e.Left.GetPos(), "%s operator with invalid left expression %s", op, exp)
 	}
 
 	switch exp := e.Right.(type) {
@@ -75,21 +70,22 @@ func (e *BinaryOpExpr) checkWithMath() error {
 			if e.Right.ReturnType() == TSTR {
 				rstring = true
 			} else {
-				return fmt.Errorf("Syntax Error: %s operator has wrong type of right expression %s", op, exp)
+				return NewSyntaxError(e.Right.GetPos(), "%s operator has wrong type of right expression %s", op, exp)
 			}
 		}
 	case *StringExpr, *FieldExpr, *FieldAccessExpr:
 		rstring = true
 	default:
-		return fmt.Errorf("Syntax Error: %s operator with invalid right expression %s", op, exp)
+		return NewSyntaxError(e.Right.GetPos(), "%s operator with invalid right expression %s", op, exp)
 	}
+
 	if op == "+" && lstring && rstring {
 	} else {
 		if lstring {
-			return fmt.Errorf("Syntax Error: %s operator with invalid left expression %s", op, e.Left)
+			return NewSyntaxError(e.Left.GetPos(), "%s operator with invalid left expression %s", op, e.Left)
 		}
 		if rstring {
-			return fmt.Errorf("Syntax Error: %s operator with invalid right expression %s", op, e.Right)
+			return NewSyntaxError(e.Right.GetPos(), "%s operator with invalid right expression %s", op, e.Left)
 		}
 	}
 	return nil
@@ -115,7 +111,7 @@ func (e *BinaryOpExpr) checkWithCompares() error {
 		numCallExpr++
 	case *StringExpr, *BoolExpr, *NumberExpr, *FloatExpr, *BinaryOpExpr, *FieldAccessExpr:
 	default:
-		return fmt.Errorf("Syntax Error: %s operator with invalid left expression", op)
+		return NewSyntaxError(e.Left.GetPos(), "%s operator with invalid left expression", op)
 	}
 
 	switch exp := e.Right.(type) {
@@ -130,31 +126,26 @@ func (e *BinaryOpExpr) checkWithCompares() error {
 		numCallExpr++
 	case *StringExpr, *BoolExpr, *NumberExpr, *FloatExpr, *BinaryOpExpr, *FieldAccessExpr:
 	default:
-		return fmt.Errorf("Syntax Error: %s operator with invalid right expression", op)
+		return NewSyntaxError(e.Right.GetPos(), "%s operator with invalid right expression", op)
 	}
 
 	if numKeyFieldExpr == 2 || numValueFieldExpr == 2 {
-		return fmt.Errorf("Syntax Error: %s operator with two same field", op)
+		return NewSyntaxError(e.GetPos(), "%s operator with two same field", op)
 	}
-	/*
-		if numKeyFieldExpr == 0 && numValueFieldExpr == 0 && numCallExpr == 0 {
-			return fmt.Errorf("Syntax Error: %s operator with no field nor function call", op)
-		}
-	*/
 
 	ltype := e.Left.ReturnType()
 	rtype := e.Right.ReturnType()
 	if ltype != rtype {
-		return fmt.Errorf("Syntax Error: %s operator left and right type not same", op)
+		return NewSyntaxError(e.GetPos(), "%s operator left and right type not same", op)
 	}
 	switch e.Op {
 	case Gt, Gte, Lt, Lte:
 		if ltype != TNUMBER && ltype != TSTR {
-			return fmt.Errorf("Syntax Error: %s operator has wrong type of left expression", op)
+			return NewSyntaxError(e.Left.GetPos(), "%s operator has wrong type of left expression", op)
 		}
 	case PrefixMatch, RegExpMatch:
 		if ltype != TSTR {
-			return fmt.Errorf("Syntax Error: %s operator has wrong type of left expression", op)
+			return NewSyntaxError(e.Left.GetPos(), "%s operator has wrong type of left expression", op)
 		}
 	}
 	return nil
@@ -166,11 +157,11 @@ func (e *BinaryOpExpr) checkWithIn() error {
 	case *ListExpr:
 		for _, expr := range r.List {
 			if expr.ReturnType() != ltype {
-				return fmt.Errorf("Syntax Error: in operator right element has wrong type")
+				return NewSyntaxError(expr.GetPos(), "in operator element has wrong type")
 			}
 		}
 	default:
-		return fmt.Errorf("Syntax Error: in operator right must be list expression")
+		return NewSyntaxError(e.Right.GetPos(), "in operator right expression must be list expression")
 	}
 	return nil
 }
@@ -179,19 +170,19 @@ func (e *BinaryOpExpr) checkWithBetween() error {
 	ltype := e.Left.ReturnType()
 	rlist, ok := e.Right.(*ListExpr)
 	if !ok || len(rlist.List) != 2 {
-		return fmt.Errorf("Syntax Error: between operator invalid right expression")
+		return NewSyntaxError(e.Right.GetPos(), "between operator invalid right expression")
 	}
 
 	switch ltype {
 	case TSTR, TNUMBER:
 	default:
-		return fmt.Errorf("Syntax Error: between operator only support string and number type")
+		return NewSyntaxError(e.Left.GetPos(), "between operator only support string and number type")
 	}
 
 	lexpr := rlist.List[0]
 	uexpr := rlist.List[1]
 	if lexpr.ReturnType() != ltype || uexpr.ReturnType() != ltype {
-		return fmt.Errorf("Syntax Error: between operator invalid right expression type")
+		return NewSyntaxError(e.Right.GetPos(), "between operator right expression with wrong type")
 	}
 	return nil
 }
@@ -206,7 +197,7 @@ func (e *StringExpr) Check() error {
 
 func (e *NotExpr) Check() error {
 	if e.Right.ReturnType() != TBOOL {
-		return errors.New("Syntax Error: ! operator followed wrong type expression")
+		return NewSyntaxError(e.Right.GetPos(), "! operator right expression has wrong type")
 	}
 	return nil
 }
@@ -214,7 +205,7 @@ func (e *NotExpr) Check() error {
 func (e *FunctionCallExpr) Check() error {
 	_, ok := e.Name.(*NameExpr)
 	if !ok {
-		return errors.New("Syntax Error: Invalid function name")
+		return NewSyntaxError(e.Name.GetPos(), "Invalid function name")
 	}
 	if len(e.Args) > 0 {
 		for _, a := range e.Args {
@@ -244,13 +235,13 @@ func (e *BoolExpr) Check() error {
 
 func (e *ListExpr) Check() error {
 	if len(e.List) == 0 {
-		return fmt.Errorf("Syntax Error: Empty list")
+		return NewSyntaxError(e.GetPos(), "Empty list")
 	}
 	if len(e.List) > 1 {
 		ftype := e.List[0].ReturnType()
 		for i, item := range e.List[1:] {
 			if item.ReturnType() != ftype {
-				return fmt.Errorf("Syntax Error: List %d item has wrong type", i)
+				return NewSyntaxError(item.GetPos(), "List %d item has wrong type", i)
 			}
 		}
 	}
@@ -265,7 +256,7 @@ func (e *FieldAccessExpr) Check() error {
 		if leftIsFAE {
 			return nil
 		}
-		return fmt.Errorf("Syntax Error: field access expression left not JSON type")
+		return NewSyntaxError(e.Left.GetPos(), "Field access expression left require JSON type")
 	}
 	switch e.FieldName.(type) {
 	case *StringExpr:
@@ -277,5 +268,5 @@ func (e *FieldAccessExpr) Check() error {
 			return nil
 		}
 	}
-	return fmt.Errorf("Syntax Error: invalid field name in field access expression")
+	return NewSyntaxError(e.GetPos(), "Invalid field name")
 }

--- a/query/errors.go
+++ b/query/errors.go
@@ -87,6 +87,9 @@ func (e *ExecuteError) queryError() string {
 func outputQueryAndErrPos(query string, pos int, adjust int) string {
 	tquery := strings.TrimSpace(query)
 	qlen := len(tquery)
+	if pos == -1 {
+		pos = qlen
+	}
 	trimLeft := false
 	trimRight := false
 	if qlen > 70 {

--- a/query/errors.go
+++ b/query/errors.go
@@ -1,0 +1,124 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+)
+
+var (
+	_ error       = (*SyntaxError)(nil)
+	_ error       = (*ExecuteError)(nil)
+	_ QueryBinder = (*SyntaxError)(nil)
+	_ QueryBinder = (*ExecuteError)(nil)
+)
+
+type QueryBinder interface {
+	BindQuery(query string)
+}
+
+type SyntaxError struct {
+	Query   string
+	Message string
+	Pos     int
+}
+
+func NewSyntaxError(pos int, msg string, args ...any) error {
+	return &SyntaxError{
+		Message: fmt.Sprintf(msg, args...),
+		Pos:     pos,
+	}
+}
+
+func (e *SyntaxError) BindQuery(query string) {
+	e.Query = query
+}
+
+func (e *SyntaxError) Error() string {
+	if e.Query == "" {
+		return e.simpleError()
+	}
+	return e.queryError()
+}
+
+func (e *SyntaxError) queryError() string {
+	ret := outputQueryAndErrPos(e.Query, e.Pos, 7)
+	ret += fmt.Sprintf("       Syntax Error: %s", e.Message)
+	return ret
+}
+
+func (e *SyntaxError) simpleError() string {
+	return fmt.Sprintf("Syntax Error: %s at %d", e.Message, e.Pos)
+}
+
+type ExecuteError struct {
+	Query   string
+	Message string
+	Pos     int
+}
+
+func NewExecuteError(pos int, msg string, args ...any) error {
+	return &ExecuteError{
+		Pos:     pos,
+		Message: fmt.Sprintf(msg, args...),
+	}
+}
+
+func (e *ExecuteError) BindQuery(query string) {
+	e.Query = query
+}
+
+func (e *ExecuteError) Error() string {
+	if e.Query == "" {
+		return e.simpleError()
+	}
+	return e.queryError()
+}
+
+func (e *ExecuteError) simpleError() string {
+	return fmt.Sprintf("Execute Error: %s at %d", e.Message, e.Pos)
+}
+
+func (e *ExecuteError) queryError() string {
+	ret := outputQueryAndErrPos(e.Query, e.Pos, 7)
+	ret += fmt.Sprintf("Execute Error: %s", e.Message)
+	return ret
+}
+
+func outputQueryAndErrPos(query string, pos int, adjust int) string {
+	tquery := strings.TrimSpace(query)
+	qlen := len(tquery)
+	trimLeft := false
+	trimRight := false
+	if qlen > 70 {
+		if pos <= 35 {
+			tquery = tquery[0:70]
+			trimRight = true
+		} else {
+			trimLeft = true
+			trim := pos - 35
+			restLen := qlen - trim
+			if restLen > 70 {
+				restLen = 70
+				trimRight = true
+			}
+			tquery = tquery[trim : trim+restLen]
+			pos -= trim
+		}
+	}
+	ret := ""
+	errPos := pos + adjust
+	if trimLeft {
+		ret = "... "
+		errPos += 4
+	}
+	ret += tquery
+	if trimRight {
+		ret += " ..."
+	}
+	ret += "\n"
+	for i := 0; i < errPos; i++ {
+		ret += " "
+	}
+	ret += "^--\n"
+	return ret
+}

--- a/query/expression.go
+++ b/query/expression.go
@@ -47,6 +47,7 @@ const (
 	TNUMBER  Type = 3
 	TIDENT   Type = 4
 	TLIST    Type = 5
+	TJSON    Type = 6
 )
 
 var (
@@ -134,6 +135,7 @@ var (
 	_ Expression = (*FloatExpr)(nil)
 	_ Expression = (*BoolExpr)(nil)
 	_ Expression = (*ListExpr)(nil)
+	_ Expression = (*FieldAccessExpr)(nil)
 )
 
 type Expression interface {
@@ -196,7 +198,7 @@ type StringExpr struct {
 }
 
 func (e *StringExpr) String() string {
-	return fmt.Sprintf("`%s`", e.Data)
+	return fmt.Sprintf("'%s'", e.Data)
 }
 
 func (e *StringExpr) ReturnType() Type {
@@ -331,4 +333,19 @@ func (e *ListExpr) String() string {
 
 func (e *ListExpr) ReturnType() Type {
 	return TLIST
+}
+
+type FieldAccessExpr struct {
+	Left      Expression
+	FieldName Expression
+}
+
+func (e *FieldAccessExpr) String() string {
+	left := e.Left.String()
+	fname := e.FieldName.String()
+	return fmt.Sprintf("%s[%s]", left, fname)
+}
+
+func (e *FieldAccessExpr) ReturnType() Type {
+	return TSTR
 }

--- a/query/expression_exec.go
+++ b/query/expression_exec.go
@@ -279,7 +279,7 @@ func (e *BinaryOpExpr) execMath(kv KVPair, op byte) (any, error) {
 	if err != nil {
 		return false, err
 	}
-	return executeMathOp(left, right, op)
+	return executeMathOp(left, right, op, e.Right)
 }
 
 func (e *BinaryOpExpr) execNumberCompare(kv KVPair, op string) (any, error) {

--- a/query/expression_exec_vec.go
+++ b/query/expression_exec_vec.go
@@ -608,6 +608,24 @@ func (e *FieldAccessExpr) execListAccessBatch(idx int, left []any) ([]any, error
 				have = true
 				fval = lval[idx]
 			}
+		case []string:
+			lvallen := len(lval)
+			if idx < lvallen {
+				have = true
+				fval = lval[idx]
+			}
+		case []int64:
+			lvallen := len(lval)
+			if idx < lvallen {
+				have = true
+				fval = lval[idx]
+			}
+		case []float64:
+			lvallen := len(lval)
+			if idx < lvallen {
+				have = true
+				fval = lval[idx]
+			}
 		case string:
 			if lval == "" {
 				have = false

--- a/query/expression_exec_vec.go
+++ b/query/expression_exec_vec.go
@@ -2,8 +2,6 @@ package query
 
 import (
 	"bytes"
-	"errors"
-	"fmt"
 	"regexp"
 )
 
@@ -17,7 +15,7 @@ func (e *StringExpr) ExecuteBatch(chunk []KVPair) ([]any, error) {
 
 func (e *FieldExpr) ExecuteBatch(chunk []KVPair) ([]any, error) {
 	if e.Field != KeyKW && e.Field != ValueKW {
-		return nil, errors.New("Invalid Field")
+		return nil, NewExecuteError(e.GetPos(), "Invalid field name %v", e.Field)
 	}
 	ret := make([]any, len(chunk))
 	isKey := e.Field == KeyKW
@@ -39,7 +37,7 @@ func (e *NotExpr) ExecuteBatch(chunk []KVPair) ([]any, error) {
 	for i := 0; i < len(chunk); i++ {
 		rval, rok := right[i].(bool)
 		if !rok {
-			return nil, errors.New("! right value error")
+			return nil, NewExecuteError(e.Right.GetPos(), "! operator right expression has wrong type, not boolean")
 		}
 		right[i] = !rval
 	}
@@ -155,7 +153,7 @@ func (e *BinaryOpExpr) ExecuteBatch(chunk []KVPair) ([]any, error) {
 			return e.execBetweenBatch(chunk, true)
 		}
 	}
-	return nil, errors.New("Unknown operator")
+	return nil, NewExecuteError(e.GetPos(), "Unknown operator %v", e.Op)
 }
 
 func (e *BinaryOpExpr) execEqualBatch(chunk []KVPair, not bool) ([]any, error) {
@@ -184,7 +182,7 @@ func (e *BinaryOpExpr) execEqualBatch(chunk []KVPair, not bool) ([]any, error) {
 	case bool:
 		isBool = true
 	default:
-		return nil, errors.New("Invalid = operator left type")
+		return nil, NewExecuteError(e.GetPos(), "= operator left expression has wrong type")
 	}
 
 	for i := 0; i < len(chunk); i++ {
@@ -192,7 +190,7 @@ func (e *BinaryOpExpr) execEqualBatch(chunk []KVPair, not bool) ([]any, error) {
 			left, lok := convertToByteArray(rleft[i])
 			right, rok := convertToByteArray(rright[i])
 			if !lok || !rok {
-				return nil, errors.New("Invalid = operator left type")
+				return nil, NewExecuteError(e.GetPos(), "= operator left or right expression has wrong type")
 			}
 			if not {
 				rleft[i] = !bytes.Equal(left, right)
@@ -204,7 +202,7 @@ func (e *BinaryOpExpr) execEqualBatch(chunk []KVPair, not bool) ([]any, error) {
 			left, lok := convertToInt(rleft[i])
 			right, rok := convertToInt(rright[i])
 			if !lok || !rok {
-				return nil, errors.New("Invalid = operator left type")
+				return nil, NewExecuteError(e.GetPos(), "= operator left or right expression has wrong type")
 			}
 			if not {
 				rleft[i] = left != right
@@ -216,7 +214,7 @@ func (e *BinaryOpExpr) execEqualBatch(chunk []KVPair, not bool) ([]any, error) {
 			left, lok := rleft[i].(bool)
 			right, rok := rright[i].(bool)
 			if !lok || !rok {
-				return nil, errors.New("Invalid = operator left type")
+				return nil, NewExecuteError(e.GetPos(), "= operator left or right expression has wrong type")
 			}
 			if not {
 				rleft[i] = left != right
@@ -241,7 +239,7 @@ func (e *BinaryOpExpr) execPrefixMatchBatch(chunk []KVPair) ([]any, error) {
 		left, lok := convertToByteArray(rleft[i])
 		right, rok := convertToByteArray(rright[i])
 		if !lok || !rok {
-			return nil, errors.New("^= left value error")
+			return nil, NewExecuteError(e.GetPos(), "^= operator left or right expression has wrong type")
 		}
 		rleft[i] = bytes.HasPrefix(left, right)
 	}
@@ -264,7 +262,7 @@ func (e *BinaryOpExpr) execRegexpMatchBatch(chunk []KVPair) ([]any, error) {
 		left, lok := convertToByteArray(rleft[i])
 		right, rok := convertToByteArray(rright[i])
 		if !lok || !rok {
-			return nil, errors.New("^= left value error")
+			return nil, NewExecuteError(e.GetPos(), "~= operator left or right expression has wrong type")
 		}
 		regKey := string(right)
 		reg, have := regexpCache[regKey]
@@ -293,7 +291,11 @@ func (e *BinaryOpExpr) execAndOrBatch(chunk []KVPair, and bool) ([]any, error) {
 		left, lok := rleft[i].(bool)
 		right, rok := rright[i].(bool)
 		if !lok || !rok {
-			return nil, errors.New("| left or right value type not bool")
+			if and {
+				return nil, NewExecuteError(e.GetPos(), "& operator left or right expression has wrong type, not boolean")
+			} else {
+				return nil, NewExecuteError(e.GetPos(), "| operator left or right expression has wrong type, not boolean")
+			}
 		}
 		if and {
 			rleft[i] = left && right
@@ -368,7 +370,7 @@ func (e *BinaryOpExpr) execInBatch(chunk []KVPair, number bool) ([]any, error) {
 	}
 	rlist, ok := e.Right.(*ListExpr)
 	if !ok {
-		return nil, errors.New("operator in right expression is not list")
+		return nil, NewExecuteError(e.GetPos(), "in operator right expression has wrong type, not list")
 	}
 	var (
 		listValues = make([][]any, len(rlist.List))
@@ -379,10 +381,10 @@ func (e *BinaryOpExpr) execInBatch(chunk []KVPair, number bool) ([]any, error) {
 
 	for l, expr := range rlist.List {
 		if number && expr.ReturnType() != TNUMBER {
-			return nil, errors.New("operator in right expression type is not number")
+			return nil, NewExecuteError(expr.GetPos(), "in operator right expression element has wrong type, not number")
 		}
 		if !number && expr.ReturnType() != TSTR {
-			return nil, errors.New("operator in right expression type is not string")
+			return nil, NewExecuteError(expr.GetPos(), "in operator right expression element has wrong type, not string")
 		}
 		values, err = expr.ExecuteBatch(chunk)
 		if err != nil {
@@ -422,21 +424,21 @@ func (e *BinaryOpExpr) execBetweenBatch(chunk []KVPair, number bool) ([]any, err
 	}
 	rlist, ok := e.Right.(*ListExpr)
 	if !ok || len(rlist.List) != 2 {
-		return nil, errors.New("operator in right expression is not list")
+		return nil, NewExecuteError(e.Right.GetPos(), "between operator right expression invalid")
 	}
 	lexpr := rlist.List[0]
 	uexpr := rlist.List[1]
 	if !number && lexpr.ReturnType() != TSTR {
-		return nil, errors.New("operator between lower boundary expression type is not string")
+		return nil, NewExecuteError(lexpr.GetPos(), "between operator lower boundary expression has wrong type, not string")
 	}
 	if !number && lexpr.ReturnType() != TSTR {
-		return nil, errors.New("operator between upper boundary expression type is not string")
+		return nil, NewExecuteError(uexpr.GetPos(), "between operator upper boundary expression has wrong type, not string")
 	}
 	if number && lexpr.ReturnType() != TNUMBER {
-		return nil, errors.New("operator between lower boundary expression type is not string")
+		return nil, NewExecuteError(lexpr.GetPos(), "between operator lower boundary expression has wrong type, not number")
 	}
 	if number && uexpr.ReturnType() != TNUMBER {
-		return nil, errors.New("operator between upper boundary expression type is not string")
+		return nil, NewExecuteError(uexpr.GetPos(), "between operator upper boundary expression has wrong type, not number")
 	}
 	lbvals, err := lexpr.ExecuteBatch(chunk)
 	if err != nil {
@@ -459,7 +461,7 @@ func (e *BinaryOpExpr) execBetweenBatch(chunk []KVPair, number bool) ([]any, err
 			return nil, err
 		}
 		if !cmp {
-			return nil, errors.New("operator between lower boundary is greater than upper boundary.")
+			return nil, NewExecuteError(e.GetPos(), "between operator lower boundary is greater than upper boundary")
 		}
 		if number {
 			lcmp, err = execNumberCompare(lbvals[i], rleft[i], "<=")
@@ -501,7 +503,7 @@ func (e *BinaryOpExpr) execStringConcateBatch(chunk []KVPair) ([]any, error) {
 		lval, lok := convertToByteArray(left[i])
 		rval, rok := convertToByteArray(right[i])
 		if !lok || !rok {
-			return nil, errors.New("+ operator left or right expression not string")
+			return nil, NewExecuteError(e.GetPos(), "+ operator left or right expression has wrong type, not string")
 		}
 		cval := make([]byte, 0, len(lval)+len(rval))
 		cval = append(cval, lval...)
@@ -527,7 +529,7 @@ func (e *FunctionCallExpr) ExecuteBatch(chunk []KVPair) ([]any, error) {
 		return nil, err
 	}
 	if !funcObj.VarArgs && len(e.Args) != funcObj.NumArgs {
-		return nil, fmt.Errorf("Function %s require %d arguments but got %d", funcObj.Name, funcObj.NumArgs, len(e.Args))
+		return nil, NewExecuteError(e.GetPos(), "Function %s require %d arguments but got %d", funcObj.Name, funcObj.NumArgs, len(e.Args))
 	}
 	return e.executeFuncBatch(funcObj, chunk)
 }
@@ -561,7 +563,7 @@ func (e *FieldAccessExpr) ExecuteBatch(chunk []KVPair) ([]any, error) {
 	case *NumberExpr:
 		return e.execListAccessBatch(int(fnval.Int), left)
 	}
-	return nil, fmt.Errorf("Invalid field name")
+	return nil, NewSyntaxError(e.FieldName.GetPos(), "Invalid field name")
 }
 
 func (e *FieldAccessExpr) execDictAccessBatch(fieldName string, left []any) ([]any, error) {
@@ -579,10 +581,10 @@ func (e *FieldAccessExpr) execDictAccessBatch(fieldName string, left []any) ([]a
 			if lval == "" {
 				have = false
 			} else {
-				return nil, fmt.Errorf("Invalid left type not JSON")
+				return nil, NewExecuteError(e.Left.GetPos(), "Field access left expression has wrong type, not JSON")
 			}
 		default:
-			return nil, fmt.Errorf("Invalid left type not JSON")
+			return nil, NewExecuteError(e.Left.GetPos(), "Field access left expression has wrong type, not JSON")
 		}
 		if !have {
 			left[i] = ""
@@ -610,10 +612,10 @@ func (e *FieldAccessExpr) execListAccessBatch(idx int, left []any) ([]any, error
 			if lval == "" {
 				have = false
 			} else {
-				return nil, fmt.Errorf("Invalid left type not List")
+				return nil, NewExecuteError(e.Left.GetPos(), "Field access left expression has wrong type, not List")
 			}
 		default:
-			return nil, fmt.Errorf("Invalid left type not List")
+			return nil, NewExecuteError(e.Left.GetPos(), "Field access left expression has wrong type, not List")
 		}
 		if !have {
 			left[i] = ""

--- a/query/expression_exec_vec.go
+++ b/query/expression_exec_vec.go
@@ -316,7 +316,7 @@ func (e *BinaryOpExpr) execMathBatch(chunk []KVPair, op byte) ([]any, error) {
 		return nil, err
 	}
 	for i := 0; i < len(chunk); i++ {
-		val, err := executeMathOp(rleft[i], rright[i], op)
+		val, err := executeMathOp(rleft[i], rright[i], op, e.Right)
 		if err != nil {
 			return nil, err
 		}

--- a/query/expression_optimizer.go
+++ b/query/expression_optimizer.go
@@ -133,9 +133,19 @@ func (o *ExpressionOptimizer) tryOptimizeBinaryOpExecute(e *BinaryOpExpr) (Expre
 			case *StringExpr:
 				return &StringExpr{Pos: leftPos, Data: ret.(string)}, true
 			case *NumberExpr:
-				return &NumberExpr{Pos: leftPos, Data: fmt.Sprintf("%v", ret), Int: ret.(int64)}, true
+				switch cret := ret.(type) {
+				case int64:
+					return &NumberExpr{Pos: leftPos, Data: fmt.Sprintf("%v", cret), Int: cret}, true
+				case float64:
+					return &NumberExpr{Pos: leftPos, Data: fmt.Sprintf("%v", int64(cret)), Int: int64(cret)}, true
+				}
 			case *FloatExpr:
-				return &FloatExpr{Pos: leftPos, Data: fmt.Sprintf("%v", ret), Float: ret.(float64)}, true
+				switch cret := ret.(type) {
+				case int64:
+					return &FloatExpr{Pos: leftPos, Data: fmt.Sprintf("%v", float64(cret)), Float: float64(cret)}, true
+				case float64:
+					return &FloatExpr{Pos: leftPos, Data: fmt.Sprintf("%v", cret), Float: cret}, true
+				}
 			}
 		}
 	case And, Or:

--- a/query/func.go
+++ b/query/func.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -18,6 +17,7 @@ var (
 		"is_float": &Function{"is_float", 1, false, TBOOL, funcIsFloat, funcIsFloatVec},
 		"substr":   &Function{"substr", 3, false, TSTR, funcSubStr, funcSubStrVec},
 		"json":     &Function{"json", 1, false, TJSON, funcJson, funcJsonVec},
+		"split":    &Function{"split", 2, false, TLIST, funcSplit, funcSplitVec},
 	}
 
 	aggrFuncMap = map[string]*AggrFunc{
@@ -60,7 +60,7 @@ type AggrFunction interface {
 func GetFuncNameFromExpr(expr Expression) (string, error) {
 	fc, ok := expr.(*FunctionCallExpr)
 	if !ok {
-		return "", errors.New("Not function call expression")
+		return "", NewSyntaxError(expr.GetPos(), "Not function call expression")
 	}
 	rfname, err := fc.Name.Execute(NewKVP(nil, nil))
 	if err != nil {
@@ -68,7 +68,7 @@ func GetFuncNameFromExpr(expr Expression) (string, error) {
 	}
 	fname, ok := rfname.(string)
 	if !ok {
-		return "", errors.New("Invalid function name")
+		return "", NewSyntaxError(expr.GetPos(), "Invalid function name")
 	}
 	return strings.ToLower(fname), nil
 }
@@ -80,7 +80,7 @@ func GetScalarFunction(expr Expression) (*Function, error) {
 	}
 	fobj, have := funcMap[fname]
 	if !have {
-		return nil, fmt.Errorf("Cannot find function %s", fname)
+		return nil, NewSyntaxError(expr.GetPos(), "Cannot find function %s", fname)
 	}
 	return fobj, nil
 }

--- a/query/func.go
+++ b/query/func.go
@@ -21,11 +21,12 @@ var (
 	}
 
 	aggrFuncMap = map[string]*AggrFunc{
-		"count": &AggrFunc{"count", 1, false, TNUMBER, newAggrCountFunc},
-		"sum":   &AggrFunc{"sum", 1, false, TNUMBER, newAggrSumFunc},
-		"avg":   &AggrFunc{"avg", 1, false, TNUMBER, newAggrAvgFunc},
-		"min":   &AggrFunc{"min", 1, false, TNUMBER, newAggrMinFunc},
-		"max":   &AggrFunc{"max", 1, false, TNUMBER, newAggrMaxFunc},
+		"count":    &AggrFunc{"count", 1, false, TNUMBER, newAggrCountFunc},
+		"sum":      &AggrFunc{"sum", 1, false, TNUMBER, newAggrSumFunc},
+		"avg":      &AggrFunc{"avg", 1, false, TNUMBER, newAggrAvgFunc},
+		"min":      &AggrFunc{"min", 1, false, TNUMBER, newAggrMinFunc},
+		"max":      &AggrFunc{"max", 1, false, TNUMBER, newAggrMaxFunc},
+		"quantile": &AggrFunc{"quantile", 2, false, TNUMBER, newAggrQuantileFunc},
 	}
 )
 
@@ -49,7 +50,7 @@ type AggrFunc struct {
 	Body       AggrFunctor
 }
 
-type AggrFunctor func() AggrFunction
+type AggrFunctor func(args []Expression) (AggrFunction, error)
 
 type AggrFunction interface {
 	Update(kv KVPair, args []Expression) error

--- a/query/func.go
+++ b/query/func.go
@@ -17,6 +17,7 @@ var (
 		"is_int":   &Function{"is_int", 1, false, TBOOL, funcIsInt, funcIsIntVec},
 		"is_float": &Function{"is_float", 1, false, TBOOL, funcIsFloat, funcIsFloatVec},
 		"substr":   &Function{"substr", 3, false, TSTR, funcSubStr, funcSubStrVec},
+		"json":     &Function{"json", 1, false, TJSON, funcJson, funcJsonVec},
 	}
 
 	aggrFuncMap = map[string]*AggrFunc{
@@ -174,12 +175,24 @@ func toInt(value any, defVal int64) int64 {
 			}
 			return defVal
 		}
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+	case int8, int16, uint8, uint16:
 		if ret, err := strconv.ParseInt(fmt.Sprintf("%d", val), 10, 64); err == nil {
 			return ret
 		} else {
 			return defVal
 		}
+	case int:
+		return int64(val)
+	case uint:
+		return int64(val)
+	case int32:
+		return int64(val)
+	case uint32:
+		return int64(val)
+	case int64:
+		return val
+	case uint64:
+		return int64(val)
 	case float32:
 		return int64(val)
 	case float64:
@@ -203,12 +216,24 @@ func toFloat(value any, defVal float64) float64 {
 		} else {
 			return defVal
 		}
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+	case int8, int16, uint8, uint16:
 		if ret, err := strconv.ParseFloat(fmt.Sprintf("%d", val), 64); err == nil {
 			return ret
 		} else {
 			return defVal
 		}
+	case int:
+		return float64(val)
+	case uint:
+		return float64(val)
+	case int32:
+		return float64(val)
+	case uint32:
+		return float64(val)
+	case int64:
+		return float64(val)
+	case uint64:
+		return float64(val)
 	case float32:
 		return float64(val)
 	case float64:

--- a/query/lexer.go
+++ b/query/lexer.go
@@ -276,31 +276,32 @@ func (l *Lexer) Split() []*Token {
 			if token != nil {
 				ret = append(ret, token)
 			}
-			if char == '(' {
+			switch char {
+			case '(':
 				token = &Token{
 					Tp:   LPAREN,
 					Data: string(char),
 					Pos:  i,
 				}
-			} else if char == ')' {
+			case ')':
 				token = &Token{
 					Tp:   RPAREN,
 					Data: string(char),
 					Pos:  i,
 				}
-			} else if char == '[' {
+			case '[':
 				token = &Token{
 					Tp:   LBRACK,
 					Data: string(char),
 					Pos:  i,
 				}
-			} else if char == ']' {
+			case ']':
 				token = &Token{
 					Tp:   RBRACK,
 					Data: string(char),
 					Pos:  i,
 				}
-			} else {
+			default:
 				token = &Token{
 					Tp:   OPERATOR,
 					Data: string(char),

--- a/query/lexer.go
+++ b/query/lexer.go
@@ -141,7 +141,7 @@ func (l *Lexer) Split() []*Token {
 				tokLen++
 				break
 			}
-			curr = l.Query[tokStart : tokStart+tokLen]
+			curr = l.Query[tokStart : tokStart+min(tokLen, l.Length-tokStart)]
 			if token := buildToken(curr, tokStartPos); token != nil {
 				ret = append(ret, token)
 			}
@@ -156,7 +156,7 @@ func (l *Lexer) Split() []*Token {
 				tokStart = i + 1
 			} else if strStartChar == char {
 				strStart = false
-				curr = l.Query[tokStart : tokStart+tokLen]
+				curr = l.Query[tokStart : tokStart+min(tokLen, l.Length-tokStart)]
 				token := &Token{
 					Tp:   STRING,
 					Data: curr,
@@ -175,7 +175,7 @@ func (l *Lexer) Split() []*Token {
 				tokStart = i + 1
 			} else if strStartChar == char {
 				strStart = false
-				curr = l.Query[tokStart : tokStart+tokLen]
+				curr = l.Query[tokStart : tokStart+min(tokLen, l.Length-tokStart)]
 				token := &Token{
 					Tp:   NAME,
 					Data: curr,
@@ -191,7 +191,7 @@ func (l *Lexer) Split() []*Token {
 				tokLen++
 				break
 			}
-			curr = l.Query[tokStart : tokStart+tokLen]
+			curr = l.Query[tokStart : tokStart+min(tokLen, l.Length-tokStart)]
 			if token := buildToken(curr, tokStartPos); token != nil {
 				ret = append(ret, token)
 			}
@@ -271,7 +271,7 @@ func (l *Lexer) Split() []*Token {
 				tokLen++
 				break
 			}
-			curr = l.Query[tokStart : tokStart+tokLen]
+			curr = l.Query[tokStart : tokStart+min(tokLen, l.Length-tokStart)]
 			token := buildToken(curr, tokStartPos)
 			if token != nil {
 				ret = append(ret, token)
@@ -317,7 +317,7 @@ func (l *Lexer) Split() []*Token {
 				tokLen++
 				break
 			}
-			curr = l.Query[tokStart : tokStart+tokLen]
+			curr = l.Query[tokStart : tokStart+min(tokLen, l.Length-tokStart)]
 			token := buildToken(curr, tokStartPos)
 			if token != nil {
 				ret = append(ret, token)
@@ -337,7 +337,7 @@ func (l *Lexer) Split() []*Token {
 		prev = char
 	}
 	if tokLen > 0 {
-		curr = l.Query[tokStart : tokStart+tokLen]
+		curr = l.Query[tokStart : tokStart+min(tokLen, l.Length-tokStart)]
 		if token := buildToken(curr, tokStartPos); token != nil {
 			ret = append(ret, token)
 		}
@@ -425,5 +425,4 @@ func buildToken(curr string, pos int) *Token {
 		token.Tp = NAME
 		return token
 	}
-	return nil
 }

--- a/query/lexer.go
+++ b/query/lexer.go
@@ -33,6 +33,8 @@ const (
 	IN       TokenType = 22
 	BETWEEN  TokenType = 23
 	AND      TokenType = 24
+	LBRACK   TokenType = 25
+	RBRACK   TokenType = 26
 )
 
 var (
@@ -61,6 +63,8 @@ var (
 		IN:       "IN",
 		BETWEEN:  "BETWEEN",
 		AND:      "AND",
+		LBRACK:   "[",
+		RBRACK:   "]",
 	}
 )
 
@@ -262,7 +266,7 @@ func (l *Lexer) Split() []*Token {
 			}
 			tokStartPos = i + 1
 			tokStart = i + 1
-		case '&', '|', '(', ')':
+		case '&', '|', '(', ')', '[', ']':
 			if strStart {
 				tokLen++
 				break
@@ -281,6 +285,18 @@ func (l *Lexer) Split() []*Token {
 			} else if char == ')' {
 				token = &Token{
 					Tp:   RPAREN,
+					Data: string(char),
+					Pos:  i,
+				}
+			} else if char == '[' {
+				token = &Token{
+					Tp:   LBRACK,
+					Data: string(char),
+					Pos:  i,
+				}
+			} else if char == ']' {
+				token = &Token{
+					Tp:   RBRACK,
 					Data: string(char),
 					Pos:  i,
 				}

--- a/query/optimizer.go
+++ b/query/optimizer.go
@@ -82,7 +82,7 @@ func (o *Optimizer) buildFinalPlan(t Txn, fp Plan) (FinalPlan, error) {
 		hasAggr = allInSelect
 	}
 	var ffp FinalPlan
-	if !hasAggr && len(o.stmt.GroupBy.Fields) > 0 {
+	if !hasAggr && o.stmt.GroupBy != nil && len(o.stmt.GroupBy.Fields) > 0 {
 		return nil, NewSyntaxError(o.stmt.Pos, "No aggregate fields in select statement")
 	}
 	if !hasAggr {

--- a/query/optimizer.go
+++ b/query/optimizer.go
@@ -156,7 +156,7 @@ func (o *Optimizer) buildFinalPlan(t Txn, fp Plan) (FinalPlan, error) {
 	return ffp, nil
 }
 
-func (o *Optimizer) BuildPlan(t Txn) (FinalPlan, error) {
+func (o *Optimizer) buildPlan(t Txn) (FinalPlan, error) {
 	err := o.init()
 	if err != nil {
 		return nil, err
@@ -181,6 +181,14 @@ func (o *Optimizer) BuildPlan(t Txn) (FinalPlan, error) {
 	}
 
 	ret, err := o.buildFinalPlan(t, fp)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (o *Optimizer) BuildPlan(t Txn) (FinalPlan, error) {
+	ret, err := o.buildPlan(t)
 	if err != nil {
 		return nil, err
 	}

--- a/query/order_plan.go
+++ b/query/order_plan.go
@@ -28,7 +28,7 @@ func (p *FinalOrderPlan) findOrderIdx(o OrderField) (int, error) {
 			return i, nil
 		}
 	}
-	return 0, fmt.Errorf("Cannot find field: %s", fname)
+	return 0, NewSyntaxError(o.Field.GetPos(), "Cannot find field: %s", fname)
 }
 
 func (p *FinalOrderPlan) Init() error {

--- a/query/parser.go
+++ b/query/parser.go
@@ -181,8 +181,14 @@ func (p *Parser) parseFuncCall(fun Expression) (Expression, error) {
 			return nil, err
 		}
 		list = append(list, arg)
-		if p.tok != nil && p.tok.Tp == RPAREN {
-			break
+		if p.tok != nil {
+			if p.tok.Tp == RPAREN {
+				break
+			} else if p.tok.Tp == SEP && p.tok.Data == "," {
+				// Correct do nothing
+			} else {
+				return nil, fmt.Errorf("Syntax Error: function argument expect `,` or  `)`")
+			}
 		}
 		p.next()
 	}
@@ -383,15 +389,22 @@ func (p *Parser) parseSelect() (*SelectStmt, error) {
 			return nil, err
 		}
 		fieldName := field.String()
-		if p.tok != nil && p.tok.Tp == AS {
-			p.next()
-			if p.tok.Tp != NAME {
-				return nil, ErrSyntaxInvalidFieldName
+		if p.tok != nil {
+			if p.tok.Tp == AS {
+				p.next()
+				if p.tok.Tp != NAME {
+					return nil, ErrSyntaxInvalidFieldName
+				}
+				fieldName = p.tok.Data
+				p.next()
+			} else if p.tok.Tp == SEP && p.tok.Data == "," {
+				// Correct do nothing
+			} else if p.tok.Tp == WHERE {
+				// Correct do nothing
+			} else {
+				return nil, fmt.Errorf("Syntax Error: expect `as` or `,`")
 			}
-			fieldName = p.tok.Data
-			p.next()
 		}
-
 		fields = append(fields, field)
 		fieldNames = append(fieldNames, fieldName)
 		fieldTypes = append(fieldTypes, field.ReturnType())

--- a/query/parser.go
+++ b/query/parser.go
@@ -58,7 +58,7 @@ func (p *Parser) expect(tok *Token) error {
 		return NewSyntaxError(-1, "Expect token %s but got EOF", tok.Data)
 	}
 	if p.tok.Tp != tok.Tp {
-		return NewSyntaxError(tok.Pos, "Expect token %s bug got %s", tok.Data, p.tok.Data)
+		return NewSyntaxError(p.tok.Pos, "Expect token %s bug got %s", tok.Data, p.tok.Data)
 	}
 	p.next()
 	return nil
@@ -464,15 +464,17 @@ func (p *Parser) parseLimit() (*LimitStmt, error) {
 		}
 	}
 	if len(exprs) > 2 {
+		if p.tok == nil {
+			return nil, NewSyntaxError(-1, "Too many limit parameters")
+		}
 		return nil, NewSyntaxError(p.tok.Pos, "Too many limit parameters")
 	}
 	switch len(exprs) {
 	case 0:
 		if p.tok == nil {
 			return nil, NewSyntaxError(-1, "Invalid limit parameters")
-		} else {
-			return nil, NewSyntaxError(p.tok.Pos, "Invalid limit parameters")
 		}
+		return nil, NewSyntaxError(p.tok.Pos, "Invalid limit parameters")
 	case 1:
 		ret.Count = int(exprs[0].Int)
 	case 2:

--- a/query/parser.go
+++ b/query/parser.go
@@ -377,6 +377,9 @@ func (p *Parser) parseSelect() (*SelectStmt, error) {
 				return nil, NewSyntaxError(p.tok.Pos, "Invalid field expression")
 			}
 			if len(fields) > 0 {
+				if p.tok == nil {
+					return nil, NewSyntaxError(-1, "Invalid field expression")
+				}
 				return nil, NewSyntaxError(p.tok.Pos, "Invalid field expression")
 			}
 			break
@@ -389,7 +392,9 @@ func (p *Parser) parseSelect() (*SelectStmt, error) {
 		if p.tok != nil {
 			if p.tok.Tp == AS {
 				p.next()
-				if p.tok.Tp != NAME {
+				if p.tok == nil {
+					return nil, NewSyntaxError(-1, "Require field name")
+				} else if p.tok.Tp != NAME {
 					return nil, NewSyntaxError(p.tok.Pos, "Invalid field name")
 				}
 				fieldName = p.tok.Data
@@ -644,10 +649,12 @@ func (p *Parser) parseOrderBy(selStmt *SelectStmt) (*OrderStmt, error) {
 
 func (p *Parser) Parse() (*SelectStmt, error) {
 	if p.numToks == 0 {
-		return nil, NewSyntaxError(p.tok.Pos, "Expect select or where keyword")
+		return nil, NewSyntaxError(-1, "Expect select or where keyword")
 	}
 	p.next()
-	if p.tok == nil || (p.tok.Tp != WHERE && p.tok.Tp != SELECT) {
+	if p.tok == nil {
+		return nil, NewSyntaxError(-1, "Expect select or where keyword")
+	} else if p.tok.Tp != WHERE && p.tok.Tp != SELECT {
 		return nil, NewSyntaxError(p.tok.Pos, "Expect select or where keyword")
 	}
 	var (

--- a/query/parser_fuzz_test.go
+++ b/query/parser_fuzz_test.go
@@ -1,0 +1,21 @@
+package query
+
+import "testing"
+
+func FuzzSQLParser(f *testing.F) {
+	tests := []string{
+		"select key, int(value) where int(key) + 1 >= 1 & (int(value) - 1 > 10 | int(value) <= 20)",
+		"select key, int(value) where key ^= 'key' order by key limit 20, 10",
+		"select * where key in ('k1', 'k2', 'k3')",
+		"select * where (key between 'k1' and 'k3') & int(value) between 1 and 10",
+		"select key, json(value)['test'] where key ^= 'k' & json(value)['test'][1] = 'v1'",
+	}
+
+	for _, t := range tests {
+		f.Add(t)
+	}
+	f.Fuzz(func(t *testing.T, query string) {
+		o := NewOptimizer(query)
+		o.buildPlan(nil)
+	})
+}

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -268,3 +268,13 @@ func TestParser24(t *testing.T) {
 	}
 	fmt.Printf("%+v\n", expr.Where.Expr.String())
 }
+
+func TestParser25(t *testing.T) {
+	query := "select key, json(value)['test'] where key ^= 'k' & json(value)['test'] = 'v1'"
+	p := NewParser(query)
+	expr, err := p.Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("%+v\n", expr.Where.Expr.String())
+}

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -278,3 +278,13 @@ func TestParser25(t *testing.T) {
 	}
 	fmt.Printf("%+v\n", expr.Where.Expr.String())
 }
+
+func TestParser26(t *testing.T) {
+	query := "select key, json(value)['test'] where key ^= 'k' & json(value)['test'][1] = 'v1'"
+	p := NewParser(query)
+	expr, err := p.Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("%+v\n", expr.Where.Expr.String())
+}

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -288,3 +288,23 @@ func TestParser26(t *testing.T) {
 	}
 	fmt.Printf("%+v\n", expr.Where.Expr.String())
 }
+
+func TestParser27(t *testing.T) {
+	query := "select key, json(value)[1] where key ^= 'k' & json(value)['test'][1] = 'v1'"
+	p := NewParser(query)
+	expr, err := p.Parse()
+	if err == nil {
+		t.Fatal("Require error")
+	}
+	fmt.Printf("%+v\n", expr.Where.Expr.String())
+}
+
+func TestParser28(t *testing.T) {
+	query := "select key, split(key, '_')[1], split(key, '_')[2] where key ^= 'k' & json(value)['test'][1] = 'v1'"
+	p := NewParser(query)
+	expr, err := p.Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("%+v\n", expr.Where.Expr.String())
+}

--- a/query/projection_plan.go
+++ b/query/projection_plan.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -100,14 +99,15 @@ func (p *ProjectionPlan) processProjection(kvp KVPair) ([]Column, error) {
 		case bool, []byte, string,
 			int, int8, int16, int32, int64,
 			uint, uint8, uint16, uint32, uint64,
-			float32, float64:
+			float32, float64,
+			JSON, map[string]any, []any:
 			ret[i] = value
 		default:
 			if value == nil {
 				ret[i] = nil
 				break
 			}
-			return nil, errors.New("Expression result type not support")
+			return nil, NewExecuteError(p.Fields[i].GetPos(), "Expression result type not support")
 		}
 	}
 	return ret, nil

--- a/query/query_txn.go
+++ b/query/query_txn.go
@@ -28,6 +28,9 @@ func NewQueryTxn(client client.Client) Txn {
 func (t *queryTxn) Get(key []byte) ([]byte, error) {
 	kv, err := t.client.Get(context.TODO(), client.Key(key))
 	if err != nil {
+		if err.Error() == "not exist" {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return kv.V, nil

--- a/query/scalar_func.go
+++ b/query/scalar_func.go
@@ -1,7 +1,9 @@
 package query
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -126,4 +128,20 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+type JSON map[string]any
+
+func funcJson(kv KVPair, args []Expression) (any, error) {
+	rarg, err := args[0].Execute(kv)
+	if err != nil {
+		return nil, err
+	}
+	jsonData, ok := convertToByteArray(rarg)
+	if !ok {
+		return nil, fmt.Errorf("Cannot convert to byte array")
+	}
+	ret := make(JSON)
+	json.Unmarshal(jsonData, &ret)
+	return ret, nil
 }

--- a/query/scalar_func.go
+++ b/query/scalar_func.go
@@ -2,8 +2,6 @@ package query
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 )
@@ -100,10 +98,10 @@ func funcSubStr(kv KVPair, args []Expression) (any, error) {
 	}
 	val := toString(rarg)
 	if args[1].ReturnType() != TNUMBER {
-		return nil, errors.New("substr function require number type parameter for second parameter")
+		return nil, NewExecuteError(args[1].GetPos(), "substr function second parameter require number type")
 	}
 	if args[2].ReturnType() != TNUMBER {
-		return nil, errors.New("substr function require number type parameter for third parameter")
+		return nil, NewExecuteError(args[2].GetPos(), "substr function third parameter require number type")
 	}
 	rarg, err = args[1].Execute(kv)
 	if err != nil {
@@ -139,9 +137,27 @@ func funcJson(kv KVPair, args []Expression) (any, error) {
 	}
 	jsonData, ok := convertToByteArray(rarg)
 	if !ok {
-		return nil, fmt.Errorf("Cannot convert to byte array")
+		return nil, NewExecuteError(args[0].GetPos(), "Cannot convert to byte array")
 	}
 	ret := make(JSON)
 	json.Unmarshal(jsonData, &ret)
+	return ret, nil
+}
+
+func funcSplit(kv KVPair, args []Expression) (any, error) {
+	rarg, err := args[0].Execute(kv)
+	if err != nil {
+		return nil, err
+	}
+	if args[1].ReturnType() != TSTR {
+		return nil, NewExecuteError(args[1].GetPos(), "split function second parameter require string type")
+	}
+	rspliter, err := args[1].Execute(kv)
+	if err != nil {
+		return nil, err
+	}
+	val := toString(rarg)
+	spliter := toString(rspliter)
+	ret := strings.Split(val, spliter)
 	return ret, nil
 }

--- a/query/scalar_func_vec.go
+++ b/query/scalar_func_vec.go
@@ -1,7 +1,9 @@
 package query
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -160,6 +162,23 @@ func funcSubStrVec(chunk []KVPair, args []Expression) ([]any, error) {
 			length = min(length, vlen-start)
 			values[i] = val[start:length]
 		}
+	}
+	return values, nil
+}
+
+func funcJsonVec(chunk []KVPair, args []Expression) ([]any, error) {
+	values, err := args[0].ExecuteBatch(chunk)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(chunk); i++ {
+		val, ok := convertToByteArray(values[i])
+		if !ok {
+			return nil, fmt.Errorf("Cannot convert to byte array")
+		}
+		item := make(JSON)
+		json.Unmarshal(val, &item)
+		values[i] = item
 	}
 	return values, nil
 }

--- a/query/statement.go
+++ b/query/statement.go
@@ -3,6 +3,7 @@ package query
 import "errors"
 
 type SelectStmt struct {
+	Pos        int
 	AllFields  bool
 	FieldNames []string
 	FieldTypes []Type
@@ -14,6 +15,7 @@ type SelectStmt struct {
 }
 
 type WhereStmt struct {
+	Pos  int
 	Expr Expression
 }
 
@@ -24,6 +26,7 @@ type OrderField struct {
 }
 
 type OrderStmt struct {
+	Pos    int
 	Orders []OrderField
 }
 
@@ -33,10 +36,12 @@ type GroupByField struct {
 }
 
 type GroupByStmt struct {
+	Pos    int
 	Fields []GroupByField
 }
 
 type LimitStmt struct {
+	Pos   int
 	Start int
 	Count int
 }

--- a/query/statement.go
+++ b/query/statement.go
@@ -1,7 +1,5 @@
 package query
 
-import "errors"
-
 type SelectStmt struct {
 	Pos        int
 	AllFields  bool
@@ -111,7 +109,7 @@ func (s *SelectStmt) checkAggrFuncArg(arg Expression) error {
 	case *FunctionCallExpr:
 		fname, err := GetFuncNameFromExpr(e)
 		if err == nil && IsAggrFunc(fname) {
-			return errors.New("Aggregate function arguments should not contains aggregate function")
+			return NewSyntaxError(arg.GetPos(), "Aggregate function arguments should not contains aggregate function")
 		}
 	}
 	return nil

--- a/query/utils.go
+++ b/query/utils.go
@@ -65,7 +65,7 @@ func convertToFloat(value any) (float64, bool) {
 	}
 }
 
-func executeMathOp(left any, right any, op byte) (any, error) {
+func executeMathOp(left any, right any, op byte, rightExpr Expression) (any, error) {
 	lint, liok := convertToInt(left)
 	rint, riok := convertToInt(right)
 	if liok && riok {
@@ -77,6 +77,9 @@ func executeMathOp(left any, right any, op byte) (any, error) {
 		case '*':
 			return lint * rint, nil
 		case '/':
+			if rint == 0 {
+				return 0, NewExecuteError(rightExpr.GetPos(), "Divide by zero")
+			}
 			return lint / rint, nil
 		default:
 			return 0.0, errors.New("Unknown operator")
@@ -94,6 +97,9 @@ func executeMathOp(left any, right any, op byte) (any, error) {
 		case '*':
 			return lfloat * rfloat, nil
 		case '/':
+			if rfloat == 0.0 {
+				return 0, NewExecuteError(rightExpr.GetPos(), "Divide by zero")
+			}
 			return lfloat / rfloat, nil
 		default:
 			return 0.0, errors.New("Unknown operator")
@@ -121,6 +127,9 @@ func executeMathOp(left any, right any, op byte) (any, error) {
 	case '*':
 		return lfval * rfval, nil
 	case '/':
+		if rfval == 0.0 {
+			return 0, NewExecuteError(rightExpr.GetPos(), "Divide by zero")
+		}
 		return lfval / rfval, nil
 	default:
 		return 0.0, errors.New("Unknown operator")


### PR DESCRIPTION
Add JSON value access support.
Example:

```
q select key, json(value)['data'] where key ^= 'k' & int(json(value)['filter']['number']) > 10
q select key, json(value)['list'][1] where key ^= 'k'
```

By the way, error report system has refactored. It will provide better error report.